### PR TITLE
Add user access token link getter 

### DIFF
--- a/.tutorials/HOW_TO_GET_USER_ACCESS_TOKENS.md
+++ b/.tutorials/HOW_TO_GET_USER_ACCESS_TOKENS.md
@@ -5,6 +5,8 @@ How can you fix this? You need to set an `User Access token`. To get that you ne
 
 `https://id.twitch.tv/oauth2/authorize?client_id=<CLIENTID>&redirect_uri=<REDIRECTURI>&response_type=token&scope=SCOPES`
 
+By the way, you can also just call `JTABot#getUserAccessTokenLink()` after setting the redirect uri using `JTABot#setRedirectUri(String)` and the needed scopes using `JTABot#setNeededPermissions(EnumSet<Permission>)` and then opening the link the method returns.
+
 After opening the page, if done correctly, you should get redirected to a web page with the following pattern:
 `<REDIRECTURI>#access_token=<ACCESSTOKEN>`
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>de.arnomann.martin</groupId>
-    <artifactId>JTA</artifactId>
-    <version>2.0.0</version>
 
+    <artifactId>JTA</artifactId>
+    <version>2.1.0</version>
     <name>JTA - Java Twitch API</name>
     <description>A Java wrapper for the Twitch API</description>
 

--- a/src/main/java/de/arnomann/martin/jta/api/JTABot.java
+++ b/src/main/java/de/arnomann/martin/jta/api/JTABot.java
@@ -3,6 +3,7 @@ package de.arnomann.martin.jta.api;
 import de.arnomann.martin.jta.api.entities.*;
 import de.arnomann.martin.jta.api.events.Listener;
 
+import java.net.URL;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,12 @@ public interface JTABot {
      * @return the new token.
      */
     String getToken();
+
+    /**
+     * Returns the user access token link to using the needed permissions set with {@link JTABot#addNeededPermissions(EnumSet)} and {@link JTABot#removeNeededPermissions(EnumSet)}.
+     * @return the generated link as {@link java.net.URL}.
+     */
+    URL getUserAccessTokenLink();
 
     /**
      * Sets the user access token. A detailed manual on how to get this can be found <a href="https://github.com/NitramMann21/JTA/blob/development/.tutorials/HOW_TO_GET_USER_ACCESS_TOKENS.md">here</a>.

--- a/src/main/java/de/arnomann/martin/jta/internal/JTABotImpl.java
+++ b/src/main/java/de/arnomann/martin/jta/internal/JTABotImpl.java
@@ -26,6 +26,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.*;
 
 public class JTABotImpl implements JTABot {
@@ -71,6 +73,26 @@ public class JTABotImpl implements JTABot {
             }
         }
         return accessToken;
+    }
+
+    @Override
+    public URL getUserAccessTokenLink() {
+        StringBuilder sb = new StringBuilder();
+
+        for(int i = 0; i < neededPermissions.size(); i++) {
+            sb.append(neededPermissions.get(i));
+            if((i + 1) != neededPermissions.size())
+                sb.append(" ");
+        }
+
+        String BASELINK = "https://id.twitch.tv/oauth2/authorize?client_id={}&redirect_uri={}&response_type=token&scope={}";
+
+        try {
+            return new URL(Helpers.format(BASELINK, getClientId(), redirectUri, sb.toString()));
+        } catch (MalformedURLException ignored) {
+            // WILL NEVER HAPPEN
+            return null;
+        }
     }
 
     @Override

--- a/src/main/java/de/arnomann/martin/jta/internal/entities/StreamImpl.java
+++ b/src/main/java/de/arnomann/martin/jta/internal/entities/StreamImpl.java
@@ -21,7 +21,6 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.Map;
 
 public class StreamImpl implements Stream {


### PR DESCRIPTION
# Pull Request

- [x] I looked for similar pull requests
- [x] I looked for upcoming updates

### What does this change?
- [x] Documentation (only API, not internal)
- [x] Code
- [ ] Repository README
- [x] Other: `HOW_TO_GET_USER_ACCESS_TOKENS.md-File`

### Description
This pull request adds the method `JTABot#getUserAccessTokenLink()`
